### PR TITLE
Implement basic plumber management app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Codex
+# Gestionale Idraulico
+
+Questo progetto contiene un esempio minimo di web app per la gestione degli interventi di un idraulico.
+
+## Avvio rapido
+
+1. Installare le dipendenze (richiede connessione a internet):
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Avviare il server:
+   ```bash
+   npm start
+   ```
+3. Aprire il browser su `http://localhost:3000` per visualizzare l'applicazione.
+
+Il server espone un'API REST `/api/appointments` per la gestione degli appuntamenti e serve i file statici del frontend.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const app = express();
+const path = require("path");
+app.use(express.static(path.join(__dirname, "../frontend/public")));
+app.use(express.json());
+
+let appointments = [];
+
+app.get('/api/appointments', (req, res) => {
+  res.json(appointments);
+});
+
+app.post('/api/appointments', (req, res) => {
+  const appointment = req.body;
+  appointment.id = appointments.length + 1;
+  appointments.push(appointment);
+  res.status(201).json(appointment);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -1,0 +1,22 @@
+const form = document.getElementById('appointmentForm');
+const list = document.getElementById('appointments');
+
+async function load() {
+  const res = await fetch('/api/appointments');
+  const data = await res.json();
+  list.innerHTML = data.map(a => `<li>#${a.id} - ${a.desc}</li>`).join('');
+}
+
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const desc = document.getElementById('desc').value;
+  await fetch('/api/appointments', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({desc})
+  });
+  form.reset();
+  load();
+});
+
+load();

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestionale Idraulico</title>
+</head>
+<body>
+  <h1>Gestionale Idraulico</h1>
+  <form id="appointmentForm">
+    <input type="text" id="desc" placeholder="Descrizione" required />
+    <button type="submit">Aggiungi Appuntamento</button>
+  </form>
+  <ul id="appointments"></ul>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize backend Node.js server with Express
- add in-memory appointments API
- serve simple frontend with form to add appointments
- document usage steps

## Testing
- `npm install express` *(fails: 403 Forbidden)*
- `node backend/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6868190f0bc48327969756a0e7195cf5